### PR TITLE
feat: Builder generation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,17 +12,17 @@ max_line_length = 80
 [*.kt]
 indent_style = space
 indent_size = 4
-max_line_length = 105
+max_line_length = 100
 
 [*.kts]
 indent_style = space
 indent_size = 4
-max_line_length = 105
+max_line_length = 100
 
 [*.java]
 indent_style = space
 indent_size = 4
-max_line_length = 105
+max_line_length = 100
 
 [*.toml]
 indent_style = space

--- a/client-codegen/build.gradle.kts
+++ b/client-codegen/build.gradle.kts
@@ -47,4 +47,3 @@ tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
-

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/CodegenUtils.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/CodegenUtils.kt
@@ -8,31 +8,39 @@ import software.amazon.smithy.utils.CaseUtils
 import software.amazon.smithy.utils.StringUtils
 import java.net.URL
 
-class CodegenUtils {
-    companion object {
-        // TODO Refer smithy-java for resource loading
-        private final val RESERVED_WORDS_FILE: URL = this.javaClass.getResource("/reserved-words.txt")!!
-        private final val SHAPE_ESCAPER: ReservedWords = ReservedWordsBuilder()
-            .loadCaseInsensitiveWords(RESERVED_WORDS_FILE) { word -> word + "Shape" }
-            .build()
+object CodegenUtils {
+    // TODO Refer smithy-java for resource loading
+    private final val RESERVED_WORDS_FILE: URL = this.javaClass.getResource("/reserved-words.txt")!!
+    private final val SHAPE_ESCAPER: ReservedWords = ReservedWordsBuilder()
+        .loadCaseInsensitiveWords(RESERVED_WORDS_FILE) { word -> word + "Shape" }
+        .build()
 
-        fun getDefaultName(shape: Shape, service: ServiceShape): String {
-            val baseName: String = shape.id.getName(service)
+    fun getDefaultName(shape: Shape, service: ServiceShape): String {
+        val baseName: String = shape.id.getName(service)
 
-            val unescaped: String = if (baseName.contains("_")) {
-                CaseUtils.toPascalCase(shape.id.name)
-            } else {
-                StringUtils.capitalize(baseName)
-            }
-
-            return SHAPE_ESCAPER.escape(unescaped)
+        val unescaped: String = if (baseName.contains("_")) {
+            CaseUtils.toPascalCase(shape.id.name)
+        } else {
+            StringUtils.capitalize(baseName)
         }
 
-        fun toModName(s: String): String {
-            // split on . and then convert to pascal case and then join with .
-            return s.split('.').joinToString(".") { part ->
-                CaseUtils.toPascalCase(part)
-            }
+        return SHAPE_ESCAPER.escape(unescaped)
+    }
+
+    /**
+     * Checks if the provided shape has the input trait.
+     *
+     * @param shape The shape to check
+     * @return true if the shape has the input trait, false otherwise
+     */
+    fun isInputShape(shape: Shape): Boolean {
+        return shape.hasTrait("smithy.api#input")
+    }
+
+    fun toModName(s: String): String {
+        // split on . and then convert to pascal case and then join with .
+        return s.split('.').joinToString(".") { part ->
+            CaseUtils.toPascalCase(part)
         }
     }
 }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/Constants.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/Constants.kt
@@ -24,4 +24,22 @@ object HaskellSymbol {
         .name("Either")
         .namespace("Data.Either", ".")
         .build()
+    val Functor = Symbol.builder()
+        .name("Functor")
+        .namespace("Data.Functor", ".")
+        .build()
+    val Applicative = Symbol.builder()
+        .name("Applicative")
+        .namespace("Data.Applicative", ".")
+        .build()
+    val Monad = Symbol.builder()
+        .name("Monad")
+        .namespace("Control.Monad", ".")
+        .build()
+
+    // TODO Add dependency.
+    val Text = Symbol.builder()
+        .name("Text")
+        .namespace("Data.Text", ".")
+        .build()
 }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/DirectedCodegenImpl.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/DirectedCodegenImpl.kt
@@ -17,7 +17,7 @@ class DirectedCodegenImpl :
         return HaskellSymbolProvider(
             directive.model(),
             directive.service(),
-            directive.service().id.namespace,
+            directive.service().id.namespace
         )
     }
 
@@ -45,17 +45,23 @@ class DirectedCodegenImpl :
     override fun generateService(
         directive: GenerateServiceDirective<HaskellContext, HaskellSettings>
     ) {
-        ServiceGenerator<GenerateServiceDirective<HaskellContext, HaskellSettings>>().accept(directive)
+        ServiceGenerator<GenerateServiceDirective<HaskellContext, HaskellSettings>>().accept(
+            directive
+        )
     }
 
     override fun generateStructure(
         directive: GenerateStructureDirective<HaskellContext, HaskellSettings>
     ) {
-        StructureGenerator<GenerateStructureDirective<HaskellContext, HaskellSettings>>().accept(directive)
+        StructureGenerator<GenerateStructureDirective<HaskellContext, HaskellSettings>>(directive).run()
     }
 
-    override fun generateOperation(directive: GenerateOperationDirective<HaskellContext, HaskellSettings>) {
-        OperationGenerator<GenerateOperationDirective<HaskellContext, HaskellSettings>>().accept(directive)
+    override fun generateOperation(
+        directive: GenerateOperationDirective<HaskellContext, HaskellSettings>
+    ) {
+        OperationGenerator<GenerateOperationDirective<HaskellContext, HaskellSettings>>().accept(
+            directive
+        )
     }
 
     override fun generateEnumShape(
@@ -75,7 +81,9 @@ class DirectedCodegenImpl :
     override fun generateIntEnumShape(
         directive: GenerateIntEnumDirective<HaskellContext, HaskellSettings>
     ) {
-        IntEnumGenerator<GenerateIntEnumDirective<HaskellContext, HaskellSettings>>().accept(directive)
+        IntEnumGenerator<GenerateIntEnumDirective<HaskellContext, HaskellSettings>>().accept(
+            directive
+        )
     }
 
     // This where we are supposed to generate things like dependency manifests and README.

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellImportContainer.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellImportContainer.kt
@@ -20,7 +20,7 @@ class HaskellImportContainer(private val modName: String) : ImportContainer {
         val orderedImports = imports.values.filter { s -> s.size == 1 }
             .map { s -> s.first() }
             .filter { s -> s.namespace != modName }
-            .map { s -> "import ${s.namespace}" }
+            .map { s -> "import qualified ${s.namespace}" }
             .sorted()
 
         return orderedImports.joinToString(System.lineSeparator())

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellSettings.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellSettings.kt
@@ -12,7 +12,10 @@ data class HaskellSettings(
     companion object {
         fun fromNode(settings: ObjectNode): HaskellSettings {
             val builder = HaskellSettingsBuilder()
-            settings.expectStringMember("service") { id -> builder.serviceShapeId = ShapeId.from(id) }
+            settings.expectStringMember("service", {
+                    id ->
+                builder.serviceShapeId = ShapeId.from(id)
+            })
                 .expectStringMember("packageName") { pname -> builder.packageName = pname }
                 .expectStringMember("edition") { e -> builder.edition = e }
                 .expectStringMember("version") { e -> builder.version = e }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellSymbolProvider.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellSymbolProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("all")
-
 package io.superposition.smithy.haskell.client.codegen
 
 import software.amazon.smithy.codegen.core.CodegenException
@@ -7,12 +5,12 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.*
+import software.amazon.smithy.model.traits.RequiredTrait
 import java.util.logging.Logger
 
 // TODO
 // Handle nullability.
 // Handle sparse lists.
-// Handle trait based validation on primitives.
 
 fun <T : Shape> T.toSymbolBuilder(): Symbol.Builder {
     return Symbol.builder()
@@ -24,10 +22,11 @@ private fun Symbol.Builder.projectNamespace(namespace: String): Symbol.Builder {
     return this.namespace(namespace, ".").definitionFile(path)
 }
 
+@Suppress("TooManyFunctions")
 class HaskellSymbolProvider(
     private val model: Model,
     private val service: ServiceShape,
-    namespace: String,
+    namespace: String
 ) : SymbolProvider, ShapeVisitor<Symbol> {
     private val logger: Logger = Logger.getLogger(this.javaClass.name)
     private val namespace: String = CodegenUtils.toModName(namespace)
@@ -52,23 +51,30 @@ class HaskellSymbolProvider(
     override fun memberShape(shape: MemberShape): Symbol {
         val target = model.getShape(shape.target)
             .orElseThrow<CodegenException> {
-                CodegenException(
-                    (
-                        "Could not find shape " + shape.target + " targeted by " +
-                            shape
-                        )
-                )
+                CodegenException("Could not find shape ${shape.target} targeted by $shape")
             }
 
-        return toSymbol(target)
+        return toSymbol(target).let {
+            if (!shape.hasTrait(RequiredTrait.ID)) {
+                it.toMaybe()
+            } else {
+                it
+            }
+        }
     }
 
     override fun booleanShape(shape: BooleanShape): Symbol {
-        return Symbol.builder().name("Bool").putProperty(SymbolProperties.IS_PRIMITIVE, true).build()
+        return Symbol.builder()
+            .name("Bool")
+            .putProperty(SymbolProperties.IS_PRIMITIVE, true)
+            .build()
     }
 
     override fun integerShape(shape: IntegerShape): Symbol {
-        return Symbol.builder().name("Integer").putProperty(SymbolProperties.IS_PRIMITIVE, true).build()
+        return Symbol.builder()
+            .name("Integer")
+            .putProperty(SymbolProperties.IS_PRIMITIVE, true)
+            .build()
     }
 
     override fun stringShape(shape: StringShape): Symbol {
@@ -80,11 +86,17 @@ class HaskellSymbolProvider(
     }
 
     override fun doubleShape(shape: DoubleShape): Symbol {
-        return Symbol.builder().name("Double").putProperty(SymbolProperties.IS_PRIMITIVE, true).build()
+        return Symbol.builder()
+            .name("Double")
+            .putProperty(SymbolProperties.IS_PRIMITIVE, true)
+            .build()
     }
 
     override fun floatShape(shape: FloatShape?): Symbol {
-        return Symbol.builder().name("Float").putProperty(SymbolProperties.IS_PRIMITIVE, true).build()
+        return Symbol.builder()
+            .name("Float")
+            .putProperty(SymbolProperties.IS_PRIMITIVE, true)
+            .build()
     }
 
     override fun longShape(shape: LongShape): Symbol {
@@ -153,7 +165,7 @@ class HaskellSymbolProvider(
     override fun operationShape(shape: OperationShape): Symbol {
         val name = CodegenUtils.getDefaultName(shape, service)
         return Symbol.builder()
-            .name(name)
+            .name(name.replaceFirstChar { it.lowercase() })
             .putProperty(SymbolProperties.IS_PRIMITIVE, false)
             .projectNamespace("$namespace.Command.$name")
             .build()
@@ -182,123 +194,4 @@ class HaskellSymbolProvider(
             .putProperty(SymbolProperties.IS_PRIMITIVE, true)
             .name("[]").addReference(shape.member.accept(this)).build()
     }
-
-//    private fun addDependencies(builder: Symbol.Builder, shape: Shape) {
-//        // REVIEW Should the Hat(^) be in the version? Can use an ADT instead.
-//        when (shape) {
-//            is StringShape -> {
-//                builder.addDependency(
-//                    SymbolDependency.builder()
-//                        .packageName("text")
-//                        .version("^1.2")
-//                        .build()
-//                )
-//            }
-//
-//            is BlobShape -> {
-//                builder.addDependency(
-//                    SymbolDependency.builder()
-//                        .packageName("bytestring")
-//                        .version("^0.11")
-//                        .build()
-//                )
-//            }
-//
-//            is TimestampShape -> {
-//                builder.addDependency(
-//                    SymbolDependency.builder()
-//                        .packageName("time")
-//                        .version("^1.9")
-//                        .build()
-//                )
-//            }
-//
-//            is MapShape -> {
-//                builder.addDependency(
-//                    SymbolDependency.builder()
-//                        .packageName("containers")
-//                        .version("^0.6")
-//                        .build()
-//                )
-//            }
-//
-//            is ListShape -> {
-//                builder.addDependency(
-//                    SymbolDependency.builder()
-//                        .packageName("base")
-//                        .version("^4.12")
-//                        .build()
-//                )
-//            }
-//        }
-//    }
-//
-//    private fun toHaskellTypeName(shape: Shape): String {
-//        // Convert shape name to PascalCase for Haskell type names
-//        return when (shape) {
-//            is StructureShape, is UnionShape, is EnumShape -> shape.id.name
-//            is StringShape -> "Text"
-//            is BooleanShape -> "Bool"
-//            is ByteShape, is ShortShape, is IntegerShape -> "Int"
-//            is LongShape, is BigIntegerShape -> "Integer"
-//            is FloatShape, is DoubleShape, is BigDecimalShape -> "Double"
-//            is BlobShape -> "ByteString"
-//            is TimestampShape -> "UTCTime"
-//            is ListShape -> "List"
-//            is MapShape -> "Map"
-//            else -> error("Unknown shape type $shape encountered while creating a symbol.")
-//        }
-//    }
-//
-//    private fun getNamespace(shape: Shape): String {
-//        // Create appropriate module namespace based on shape's namespace
-//        val namespace = shape.id.namespace
-//
-//        // Convert namespace to Haskell module path
-//        return if (namespace.isEmpty()) {
-//            pkgName
-//        } else {
-//            "$pkgName.$namespace"
-//        }
-//    }
-//
-//    private fun getDefinitionFile(shape: Shape): String {
-//        // Convert shape name to file path
-//        val typeName = toHaskellTypeName(shape)
-//        return "$typeName.hs"
-//    }
-//
-//    private fun addReferences(builder: Symbol.Builder, shape: Shape) {
-//        when (shape) {
-//            is ListShape -> {
-//                // Add reference to member type
-//                val memberTarget = model.expectShape(shape.member.target)
-//                builder.addReference(toSymbol(memberTarget))
-//            }
-//
-//            is MapShape -> {
-//                // Add references to key and value types
-//                val keyTarget = model.expectShape(shape.key.target)
-//                val valueTarget = model.expectShape(shape.value.target)
-//                builder.addReference(toSymbol(keyTarget))
-//                builder.addReference(toSymbol(valueTarget))
-//            }
-//
-//            is StructureShape -> {
-//                // Add references to all member types
-//                shape.members().forEach { member ->
-//                    val memberTarget = model.expectShape(member.target)
-//                    builder.addReference(toSymbol(memberTarget))
-//                }
-//            }
-//
-//            is UnionShape -> {
-//                // Add references to all member types
-//                shape.members().forEach { member ->
-//                    val memberTarget = model.expectShape(member.target)
-//                    builder.addReference(toSymbol(memberTarget))
-//                }
-//            }
-//        }
-//    }
 }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/SymbolExt.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/SymbolExt.kt
@@ -1,17 +1,34 @@
 package io.superposition.smithy.haskell.client.codegen
 
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolReference
 import kotlin.jvm.optionals.getOrDefault
 
-fun Symbol.isPrimitive(): Boolean = this.getProperty(SymbolProperties.IS_PRIMITIVE).getOrDefault(false)
+fun Symbol.isPrimitive(): Boolean = this.getProperty(SymbolProperties.IS_PRIMITIVE).getOrDefault(
+    false
+)
 
 fun Symbol.wrap(sym: Symbol) = sym.toBuilder().addReference(this).build()
 
-fun Symbol.toMaybe() = this.wrap(HaskellSymbol.Maybe)
+fun Symbol.isMaybe() =
+    this.name == HaskellSymbol.Maybe.name &&
+        this.namespace == HaskellSymbol.Maybe.namespace
 
-fun Symbol.toEither(right: Symbol) = right.wrap(HaskellSymbol.Either)
+fun Symbol.toMaybe(): Symbol {
+    if (this.isMaybe()) {
+        return this
+    }
+    return this.wrap(HaskellSymbol.Maybe)
+}
+
+fun Symbol.toEither(right: Symbol) = this.wrap(HaskellSymbol.Either)
     .toBuilder()
-    .addReference(this)
+    .addReference(right)
     .build()
 
 fun Symbol.inIO() = this.wrap(HaskellSymbol.IO)
+
+fun SymbolReference.isDeclare() =
+    this.getOptions().any { it == SymbolReference.ContextOption.DECLARE }
+
+fun SymbolReference.isUse() = this.getOptions().any { it == SymbolReference.ContextOption.USE }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/BuilderGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/BuilderGenerator.kt
@@ -1,0 +1,134 @@
+package io.superposition.smithy.haskell.client.codegen.generators
+
+import io.superposition.smithy.haskell.client.codegen.HaskellWriter
+import io.superposition.smithy.haskell.client.codegen.isMaybe
+import io.superposition.smithy.haskell.client.codegen.toMaybe
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.utils.CaseUtils
+
+class BuilderGenerator(
+    val shape: StructureShape,
+    val symbol: Symbol,
+    val symbolProvider: SymbolProvider,
+    val writer: HaskellWriter
+) : Runnable {
+    private data class BuilderStateMember(
+        val name: String,
+        val symbol: Symbol,
+        val inputShape: MemberShape,
+        val inputSymbol: Symbol
+    )
+
+    private val builderName = "${shape.id.name}Builder"
+    private val stateName = "${builderName}State"
+    private val builderStateMembers = shape.members().map {
+        val name = "${symbolProvider.toMemberName(it)}BuilderState"
+        val symbol = symbolProvider.toSymbol(it).toMaybe()
+        return@map BuilderStateMember(name, symbol, it, symbolProvider.toSymbol(it))
+    }
+
+    override fun run() {
+        writer.pushState()
+        writer.putContext("builderState", Runnable(::builderStateSection))
+        writer.putContext("defaultBuilderState", Runnable(::defaultBuilderState))
+        writer.putContext("builderSetters", Runnable(::builderSetters))
+        writer.putContext("builderFunction", Runnable(::builderFunction))
+        writer.write(
+            """
+
+           #{builderState:C}
+
+           #{defaultBuilderState:C}
+
+           newtype $builderName a = $builderName {
+               run$builderName :: $stateName -> ($stateName, a)
+           }
+
+           instance #{functor:T} $builderName where
+               fmap f ($builderName g) =
+                   $builderName (\s -> let (s', a) = g s in (s', f a))
+
+           instance #{applicative:T} $builderName where
+               pure a = $builderName (\s -> (s, a))
+               ($builderName f) <*> ($builderName g) = $builderName (\s ->
+                   let (s', h) = f s
+                       (s'', a) = g s'
+                   in (s'', h a))
+
+           instance #{monad:T} $builderName where
+               ($builderName f) >>= g = $builderName (\s ->
+                   let (s', a) = f s
+                       ($builderName h) = g a
+                   in h s')
+           #{builderSetters:C}
+
+           #{builderFunction:C}
+            """.trimIndent()
+        )
+        writer.addExport(builderName)
+        writer.popState()
+    }
+
+    private fun builderStateSection() {
+        writer.openBlock("data $stateName = $stateName {", "}") {
+            builderStateMembers.forEach {
+                writer.write("${it.name} :: #T,", it.symbol)
+            }
+        }
+    }
+
+    private fun defaultBuilderState() {
+        val fn = "defaultBuilderState"
+        writer.write("$fn :: $stateName")
+        writer.openBlock("$fn = $stateName {", "}") {
+            builderStateMembers.forEach {
+                writer.write("${it.name} = #{nothing:T},")
+            }
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    private fun builderSetters() {
+        builderStateMembers.forEach {
+            val im = it.inputShape
+            val fn = CaseUtils.toCamelCase("set ${im.memberName}")
+            writer.addExport(fn)
+            writer.putContext("isMaybe", it.inputSymbol.isMaybe())
+            writer.write(
+                """
+
+                $fn :: #T -> $builderName ()
+                $fn value =
+                   $builderName (\s -> (s { ${it.name} = #{^isMaybe}#{just:T} #{/isMaybe}value }, ()))
+                """.trimIndent(),
+                symbolProvider.toSymbol(it.inputShape)
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    private fun builderFunction() {
+        val fn = "build"
+        writer.addExport(fn)
+        writer.write("$fn :: $builderName () -> #{either:T} #{text:T} ${shape.id.name}")
+        writer.openBlock("$fn builder = do", "") {
+            builderStateMembers.forEach {
+                val mn = it.inputShape.memberName
+                val e = "\"$symbol.$mn is a required property.\""
+                if (it.inputSymbol.isMaybe()) {
+                    writer.write("$mn' <- #{right:T} (${it.name} builder)")
+                } else {
+                    writer.write("$mn' <- Data.Maybe.maybe (#{left:T} $e) #{right:T} (${it.name} builder)")
+                }
+            }
+            writer.openBlock("#{right:T} (#T { ", "})", symbol) {
+                builderStateMembers.forEach {
+                    writer.write("${it.inputShape.memberName} = ${it.inputShape.memberName}',")
+                }
+            }
+        }
+    }
+}

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/OperationGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/OperationGenerator.kt
@@ -8,7 +8,7 @@ import software.amazon.smithy.codegen.core.directed.ShapeDirective
 import software.amazon.smithy.model.shapes.OperationShape
 import java.util.function.Consumer
 
-@Suppress("MaxLineLength")
+@Suppress("MaxLineLength", "ktlint:standard:max-line-length")
 class OperationGenerator<T : ShapeDirective<OperationShape, HaskellContext, HaskellSettings>> : Consumer<T> {
     override fun accept(directive: T) {
         val shape = directive.shape()
@@ -16,11 +16,17 @@ class OperationGenerator<T : ShapeDirective<OperationShape, HaskellContext, Hask
         // Generate operation code
         directive.context().writerDelegator().useShapeWriter(shape) { writer ->
             // Write operation implementation
-            val input = directive.symbolProvider().toSymbol(directive.model().expectShape(shape.inputShape))
-            val output = directive.symbolProvider().toSymbol(directive.model().expectShape(shape.outputShape))
+            val input = directive.symbolProvider().toSymbol(
+                directive.model().expectShape(shape.inputShape)
+            )
+            val output = directive.symbolProvider().toSymbol(
+                directive.model().expectShape(shape.outputShape)
+            )
 
-            writer.write("-- Operation implementation for ${shape.id.name}")
-            writer.write("${shape.id.name} :: #T -> #T", input, output)
+            val symbol = directive.symbol()
+            writer.write("#T :: ()", symbol)
+            writer.write("#T = ()", symbol)
+            writer.addExport(symbol.name)
         }
     }
 }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/ServiceGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/ServiceGenerator.kt
@@ -8,8 +8,9 @@ import software.amazon.smithy.codegen.core.directed.ShapeDirective
 import software.amazon.smithy.model.shapes.ServiceShape
 import java.util.function.Consumer
 
-class ServiceGenerator<T : ShapeDirective<ServiceShape, HaskellContext, HaskellSettings>> : Consumer<T> {
-
+class ServiceGenerator<
+    T : ShapeDirective<ServiceShape, HaskellContext, HaskellSettings>
+    > : Consumer<T> {
     override fun accept(directive: T) {
         val context = directive.context()
         val service = directive.service()

--- a/detekt.yml
+++ b/detekt.yml
@@ -41,7 +41,7 @@ formatting:
   autoCorrect: true
   MaximumLineLength:
     active: true
-    maxLineLength: 105
+    maxLineLength: 100
   Wrapping:
     active: true
   NoWildcardImports:


### PR DESCRIPTION
- Generates builder for `StructureShape`.
- Manage exports of a module via a writer.
- Added global public module list for cabal-file generation.
- SymbolProvider now maps member shape to `Maybe` if the `required` trait is not found.