### PR TITLE
build: Relaxed detekt task to not fail during build.

### DIFF
--- a/.github/workflows/gradle-detekt-lint.yaml
+++ b/.github/workflows/gradle-detekt-lint.yaml
@@ -1,4 +1,4 @@
-name: Gradle Check
+name: Gradle DetektLint
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ main, master ]
 
 jobs:
-  gradle-check:
+  gradle-detekt-lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     - name: Run Gradle check with JDK 21
       run: |
         export JAVA_HOME=$JAVA_HOME_21_X64
-        ./gradlew check --parallel
+        ./gradlew detektLint
 
     - name: Upload test results
       if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,44 +17,44 @@ allprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
 
     detekt {
-        toolVersion = detektV // Keep in sync with plugin version
+        toolVersion = detektV
         config.setFrom(files("$rootDir/detekt.yml"))
         buildUponDefaultConfig = true // Adds default rules to your custom config
-        autoCorrect = true // Automatically fixes issues when possible
-        parallel = true // Improves performance on multicore machines
+        autoCorrect = true
+        parallel = true
     }
 
     dependencies {
         detektPlugins(detektFormatter)
     }
 
-    // Configure reports on the task level instead
     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         config.setFrom(files("$rootDir/detekt.yml"))
         reports {
-            html.required.set(true)
+            html.required.set(false)
             xml.required.set(false)
             txt.required.set(false)
-            sarif.required.set(true)
+            sarif.required.set(false)
         }
+        // Ignoring errors as this will fail the build command.
+        ignoreFailures = true
     }
-}
 
-// Configure detekt to run as part of the check task
-tasks.named("check") { dependsOn(tasks.named("detekt")) }
-
-// Create a specific task just for fixing issues
-tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektFix") {
-    description = "Fix Detekt issues."
-    setSource(files("src/main/kotlin", "src/test/kotlin"))
-    config.setFrom(files("$rootDir/detekt.yml"))
-    buildUponDefaultConfig = true
-    parallel = true
-    autoCorrect = true // Ensure auto-correct is enabled
-    disableDefaultRuleSets = false
-    debug = true
-
-    reports {
-        html.required.set(true)
+    // Use this if you want to fail on errors.
+    tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektLint") {
+        setSource(files("src/main/kotlin", "src/test/kotlin"))
+        config.setFrom(files("$rootDir/detekt.yml"))
+        debug = false
+        ignoreFailures = false
+        reports {
+            html.required.set(false)
+            xml.required.set(false)
+            txt.required.set(false)
+            sarif.required.set(false)
+        }
+        include("**/*.kt")
+        include("**/*.kts")
+        exclude("resources/")
+        exclude("build/")
     }
 }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/Alias.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/Alias.kt
@@ -1,0 +1,5 @@
+package io.superposition.smithy.haskell.client.codegen
+
+import software.amazon.smithy.codegen.core.directed.ShapeDirective
+
+typealias HaskellShapeDirective<T> = ShapeDirective<T, HaskellContext, HaskellSettings>

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/ErrorGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/ErrorGenerator.kt
@@ -2,16 +2,14 @@
 
 package io.superposition.smithy.haskell.client.codegen.generators
 
-import io.superposition.smithy.haskell.client.codegen.HaskellContext
-import io.superposition.smithy.haskell.client.codegen.HaskellSettings
+import io.superposition.smithy.haskell.client.codegen.HaskellShapeDirective
 import io.superposition.smithy.haskell.client.codegen.language.Record
-import software.amazon.smithy.codegen.core.directed.ShapeDirective
 import software.amazon.smithy.model.shapes.StructureShape
 import java.util.function.Consumer
 
 // NOTE: we should probably use StructureGenerator for generating code for errors
 @Suppress("MaximumLineLength")
-class ErrorGenerator<T : ShapeDirective<StructureShape, HaskellContext, HaskellSettings>> : Consumer<T> {
+class ErrorGenerator<T : HaskellShapeDirective<StructureShape>> : Consumer<T> {
     override fun accept(directive: T) {
         val context = directive.context()
         val error = directive.shape()

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/OperationGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/OperationGenerator.kt
@@ -1,7 +1,5 @@
 @file:Suppress(
     "FINITE_BOUNDS_VIOLATION_IN_JAVA",
-    "UnusedPrivateMember",
-    "UnusedPrivateProperty"
 )
 
 package io.superposition.smithy.haskell.client.codegen.generators
@@ -11,7 +9,6 @@ import io.superposition.smithy.haskell.client.codegen.CodegenUtils.toHaskellHttp
 import io.superposition.smithy.haskell.client.codegen.HaskellSymbol.EncodingUtf8
 import io.superposition.smithy.haskell.client.codegen.language.ClientRecord
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.codegen.core.directed.ShapeDirective
 import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.knowledge.HttpBindingIndex
 import software.amazon.smithy.model.shapes.MapShape
@@ -21,13 +18,8 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.model.traits.JsonNameTrait
 
-@Suppress(
-    "MaxLineLength",
-    "ktlint:standard:max-line-length",
-    "TooManyFunctions",
-    "LargeClass"
-)
-class OperationGenerator<T : ShapeDirective<OperationShape, HaskellContext, HaskellSettings>>(
+@Suppress("MaxLineLength")
+class OperationGenerator<T : HaskellShapeDirective<OperationShape>>(
     private val directive: T
 ) {
     private val opSymbol = directive.symbol()

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/ServiceGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/ServiceGenerator.kt
@@ -2,18 +2,14 @@
 
 package io.superposition.smithy.haskell.client.codegen.generators
 
-import io.superposition.smithy.haskell.client.codegen.HaskellContext
-import io.superposition.smithy.haskell.client.codegen.HaskellSettings
+import io.superposition.smithy.haskell.client.codegen.HaskellShapeDirective
 import io.superposition.smithy.haskell.client.codegen.language.ClientRecord
 import software.amazon.smithy.codegen.core.CodegenException
-import software.amazon.smithy.codegen.core.directed.ShapeDirective
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.traits.HttpBearerAuthTrait
 import java.util.function.Consumer
 
-class ServiceGenerator<
-    T : ShapeDirective<ServiceShape, HaskellContext, HaskellSettings>
-    > : Consumer<T> {
+class ServiceGenerator<T : HaskellShapeDirective<ServiceShape>> : Consumer<T> {
     override fun accept(directive: T) {
         val context = directive.context()
         val service = directive.service()

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureGenerator.kt
@@ -2,14 +2,11 @@
 
 package io.superposition.smithy.haskell.client.codegen.generators
 
-import io.superposition.smithy.haskell.client.codegen.HaskellContext
-import io.superposition.smithy.haskell.client.codegen.HaskellSettings
+import io.superposition.smithy.haskell.client.codegen.HaskellShapeDirective
 import io.superposition.smithy.haskell.client.codegen.language.Record
-import software.amazon.smithy.codegen.core.directed.ShapeDirective
 import software.amazon.smithy.model.shapes.StructureShape
 
-@Suppress("MaxLineLength")
-class StructureGenerator<T : ShapeDirective<StructureShape, HaskellContext, HaskellSettings>>(
+class StructureGenerator<T : HaskellShapeDirective<StructureShape>>(
     private val directive: T
 ) : Runnable {
     private val shape = directive.shape()

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureSerializerGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureSerializerGenerator.kt
@@ -6,7 +6,6 @@ import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.traits.JsonNameTrait
 
-@Suppress("MaxLineLength")
 class StructureSerializerGenerator(
     private val members: Collection<MemberShape>,
     private val symbol: Symbol,

--- a/detekt.yml
+++ b/detekt.yml
@@ -16,11 +16,11 @@ comments:
 
 complexity:
   LongMethod:
-    threshold: 60
+    threshold: 100
   TooManyFunctions:
-    thresholdInFiles: 15
+    active: false
   LargeClass:
-    threshold: 200
+    active: false
   CyclomaticComplexMethod:
     threshold: 15
   StringLiteralDuplication:


### PR DESCRIPTION
The detekt task which runs as part of gradle `check` will no longer fail, it'll
just run fixes. Have setup a different task, `detektLint` for linting w/ error.