### PR TITLE
feat: Timestamp & Document symbols.

### DIFF
--- a/client-codegen-test/model/main.smithy
+++ b/client-codegen-test/model/main.smithy
@@ -100,6 +100,19 @@ operation PostMenu {
 
         @httpPrefixHeaders("x-useless-")
         versions: MapOfString
+
+        @timestampFormat("date-time")
+        dateTime: Timestamp
+
+        @timestampFormat("epoch-seconds")
+        epochSeconds: Timestamp
+
+        @timestampFormat("http-date")
+        httpDate: Timestamp
+
+        @required
+        @timestampFormat("http-date")
+        httpDateRequired: Timestamp
     }
 
     output := {
@@ -111,6 +124,15 @@ operation PostMenu {
 
         @httpHeader("x-config-tag")
         config_tag: String
+
+        @timestampFormat("http-date")
+        @httpHeader("x-last-modified")
+        httpDateOptional: Timestamp
+
+        @required
+        @timestampFormat("http-date")
+        @httpHeader("last-modified")
+        httpDateRequired: Timestamp
     }
 }
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/CoffeeItem.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/CoffeeItem.hs
@@ -28,17 +28,17 @@ data CoffeeItem = CoffeeItem {
   )
 
 instance Data.Aeson.ToJSON CoffeeItem where
-    toJSON a = Data.Aeson.object
-        [ "coffeeType" Data.Aeson..= ctype a
-        , "description" Data.Aeson..= description a
+    toJSON a = Data.Aeson.object [
+        "coffeeType" Data.Aeson..= ctype a,
+        "description" Data.Aeson..= description a
         ]
     
 
 
 instance Data.Aeson.FromJSON CoffeeItem where
     parseJSON = Data.Aeson.withObject "CoffeeItem" $ \v -> CoffeeItem
-        Data.Functor.<$> v Data.Aeson..: "coffeeType"
-        Control.Applicative.<*> v Data.Aeson..: "description"
+        Data.Functor.<$> (v Data.Aeson..: "coffeeType")
+        Control.Applicative.<*> (v Data.Aeson..: "description")
     
 
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/GetMenuInput.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/GetMenuInput.hs
@@ -20,8 +20,9 @@ data GetMenuInput = GetMenuInput {
   )
 
 instance Data.Aeson.ToJSON GetMenuInput where
-    toJSON a = Data.Aeson.object
-        []
+    toJSON a = Data.Aeson.object [
+        ]
+    
 
 
 instance Data.Aeson.FromJSON GetMenuInput where

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/GetMenuOutput.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/GetMenuOutput.hs
@@ -25,15 +25,15 @@ data GetMenuOutput = GetMenuOutput {
   )
 
 instance Data.Aeson.ToJSON GetMenuOutput where
-    toJSON a = Data.Aeson.object
-        [ "items" Data.Aeson..= items a
+    toJSON a = Data.Aeson.object [
+        "items" Data.Aeson..= items a
         ]
     
 
 
 instance Data.Aeson.FromJSON GetMenuOutput where
     parseJSON = Data.Aeson.withObject "GetMenuOutput" $ \v -> GetMenuOutput
-        Data.Functor.<$> v Data.Aeson..: "items"
+        Data.Functor.<$> (v Data.Aeson..: "items")
     
 
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/PostMenuOutput.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Model/PostMenuOutput.hs
@@ -5,46 +5,72 @@ module Com.Example.Model.PostMenuOutput (
     setItems,
     setResheaders,
     setConfigTag,
+    setHttpdateoptional,
+    setHttpdaterequired,
     build,
     PostMenuOutputBuilder,
     PostMenuOutput,
     items,
     resHeaders,
-    config_tag
+    config_tag,
+    httpDateOptional,
+    httpDateRequired
 ) where
 import qualified Com.Example.Model.CoffeeItem
 import qualified Control.Applicative
 import qualified Control.Monad
 import qualified Data.Aeson
 import qualified Data.Either
+import qualified Data.Function
 import qualified Data.Functor
 import qualified Data.Map
 import qualified Data.Maybe
 import qualified Data.Text
+import qualified Data.Text.Encoding
 import qualified GHC.Generics
+import qualified Network.HTTP.Date
 
 data PostMenuOutput = PostMenuOutput {
     items :: Com.Example.Model.CoffeeItem.CoffeeItem,
     resHeaders :: Data.Maybe.Maybe (Data.Map.Map Data.Text.Text Data.Text.Text),
-    config_tag :: Data.Maybe.Maybe Data.Text.Text
+    config_tag :: Data.Maybe.Maybe Data.Text.Text,
+    httpDateOptional :: Data.Maybe.Maybe Network.HTTP.Date.HTTPDate,
+    httpDateRequired :: Network.HTTP.Date.HTTPDate
 } deriving (
   GHC.Generics.Generic
   )
 
 instance Data.Aeson.ToJSON PostMenuOutput where
-    toJSON a = Data.Aeson.object
-        [ "items" Data.Aeson..= items a
-        , "resHeaders" Data.Aeson..= resHeaders a
-        , "config_tag" Data.Aeson..= config_tag a
+    toJSON a = Data.Aeson.object [
+        "items" Data.Aeson..= items a,
+        "resHeaders" Data.Aeson..= resHeaders a,
+        "config_tag" Data.Aeson..= config_tag a,
+        "httpDateOptional" Data.Aeson..= ((httpDateOptional a) Data.Functor.<&> (Data.Text.Encoding.decodeUtf8 . Network.HTTP.Date.formatHTTPDate)),
+        "httpDateRequired" Data.Aeson..= ((httpDateRequired a) Data.Function.& (Data.Text.Encoding.decodeUtf8 . Network.HTTP.Date.formatHTTPDate))
         ]
     
 
 
 instance Data.Aeson.FromJSON PostMenuOutput where
     parseJSON = Data.Aeson.withObject "PostMenuOutput" $ \v -> PostMenuOutput
-        Data.Functor.<$> v Data.Aeson..: "items"
-        Control.Applicative.<*> v Data.Aeson..: "resHeaders"
-        Control.Applicative.<*> v Data.Aeson..: "config_tag"
+        Data.Functor.<$> (v Data.Aeson..: "items")
+        Control.Applicative.<*> (v Data.Aeson..: "resHeaders")
+        Control.Applicative.<*> (v Data.Aeson..: "config_tag")
+        Control.Applicative.<*> (v Data.Aeson..: "httpDateOptional"
+             >>= \t -> t
+                            Data.Functor.<&> Data.Text.Encoding.encodeUtf8
+                            Data.Functor.<&> Network.HTTP.Date.parseHTTPDate
+                            Data.Functor.<&> Data.Maybe.maybe (fail "Failed to parse Com.Example.Model.PostMenuOutput.PostMenuOutput.Data.Maybe.Maybe as Network.HTTP.Date.HTTPDate") pure
+                            Data.Function.& Data.Maybe.maybe (pure Data.Maybe.Nothing) pure
+            
+            )
+        Control.Applicative.<*> (v Data.Aeson..: "httpDateRequired"
+             >>= \t -> t
+                            Data.Function.& Data.Text.Encoding.encodeUtf8
+                            Data.Function.& Network.HTTP.Date.parseHTTPDate
+                            Data.Function.& Data.Maybe.maybe (fail "Failed to parse Com.Example.Model.PostMenuOutput.PostMenuOutput.Network.HTTP.Date.HTTPDate as Network.HTTP.Date.HTTPDate") pure
+            
+            )
     
 
 
@@ -52,7 +78,9 @@ instance Data.Aeson.FromJSON PostMenuOutput where
 data PostMenuOutputBuilderState = PostMenuOutputBuilderState {
     itemsBuilderState :: Data.Maybe.Maybe Com.Example.Model.CoffeeItem.CoffeeItem,
     resHeadersBuilderState :: Data.Maybe.Maybe (Data.Map.Map Data.Text.Text Data.Text.Text),
-    config_tagBuilderState :: Data.Maybe.Maybe Data.Text.Text
+    config_tagBuilderState :: Data.Maybe.Maybe Data.Text.Text,
+    httpDateOptionalBuilderState :: Data.Maybe.Maybe Network.HTTP.Date.HTTPDate,
+    httpDateRequiredBuilderState :: Data.Maybe.Maybe Network.HTTP.Date.HTTPDate
 } deriving (
   GHC.Generics.Generic
   )
@@ -61,7 +89,9 @@ defaultBuilderState :: PostMenuOutputBuilderState
 defaultBuilderState = PostMenuOutputBuilderState {
     itemsBuilderState = Data.Maybe.Nothing,
     resHeadersBuilderState = Data.Maybe.Nothing,
-    config_tagBuilderState = Data.Maybe.Nothing
+    config_tagBuilderState = Data.Maybe.Nothing,
+    httpDateOptionalBuilderState = Data.Maybe.Nothing,
+    httpDateRequiredBuilderState = Data.Maybe.Nothing
 }
 
 newtype PostMenuOutputBuilder a = PostMenuOutputBuilder {
@@ -97,16 +127,28 @@ setConfigTag :: Data.Maybe.Maybe Data.Text.Text -> PostMenuOutputBuilder ()
 setConfigTag value =
    PostMenuOutputBuilder (\s -> (s { config_tagBuilderState = value }, ()))
 
+setHttpdateoptional :: Data.Maybe.Maybe Network.HTTP.Date.HTTPDate -> PostMenuOutputBuilder ()
+setHttpdateoptional value =
+   PostMenuOutputBuilder (\s -> (s { httpDateOptionalBuilderState = value }, ()))
+
+setHttpdaterequired :: Network.HTTP.Date.HTTPDate -> PostMenuOutputBuilder ()
+setHttpdaterequired value =
+   PostMenuOutputBuilder (\s -> (s { httpDateRequiredBuilderState = Data.Maybe.Just value }, ()))
+
 build :: PostMenuOutputBuilder () -> Data.Either.Either Data.Text.Text PostMenuOutput
 build builder = do
     let (st, _) = runPostMenuOutputBuilder builder defaultBuilderState
     items' <- Data.Maybe.maybe (Data.Either.Left "Com.Example.Model.PostMenuOutput.PostMenuOutput.items is a required property.") Data.Either.Right (itemsBuilderState st)
     resHeaders' <- Data.Either.Right (resHeadersBuilderState st)
     config_tag' <- Data.Either.Right (config_tagBuilderState st)
+    httpDateOptional' <- Data.Either.Right (httpDateOptionalBuilderState st)
+    httpDateRequired' <- Data.Maybe.maybe (Data.Either.Left "Com.Example.Model.PostMenuOutput.PostMenuOutput.httpDateRequired is a required property.") Data.Either.Right (httpDateRequiredBuilderState st)
     Data.Either.Right (PostMenuOutput { 
         items = items',
         resHeaders = resHeaders',
-        config_tag = config_tag'
+        config_tag = config_tag',
+        httpDateOptional = httpDateOptional',
+        httpDateRequired = httpDateRequired'
     })
 
 

--- a/client-codegen-test/output/source/haskell-client-codegen/project.cabal
+++ b/client-codegen-test/output/source/haskell-client-codegen/project.cabal
@@ -12,9 +12,11 @@ library
                         http-types >= 0.12.3 && < 0.13,
                         aeson >= 2.0.0 && < 2.2.0,
                         case-insensitive >= 1.2.1 && < 1.3,
+                        http-date >= 0.0.8 && < 0.1,
                         containers >= 0.6.4 && < 0.7,
                         network-uri >= 2.6 && < 2.7,
-                        http-client >= 0.5.14 && < 0.8
+                        http-client >= 0.5.14 && < 0.8,
+                        time >= 1.9 && < 1.15
     exposed-modules:    Com.Example.Model.GetMenuOutput,
                         Com.Example.Model.SomeUnion,
                         Com.Example.Model.CoffeeItem,

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/Constants.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/Constants.kt
@@ -6,6 +6,7 @@ import software.amazon.smithy.codegen.core.SymbolDependency
 
 object SymbolProperties {
     val IS_PRIMITIVE: Property<Boolean> = Property.named("is-primitive")
+    val WRAPPER_T: Property<Boolean> = Property.named("wrapper-t")
 }
 
 object HaskellDependencies {
@@ -89,6 +90,12 @@ object HaskellSymbol {
     val ParseEither = Symbol.builder().name("parseEither")
         .namespace("Data.Aeson.Types", ".")
         .build()
+    val JsonString: Symbol = Aeson.toBuilder().name("String").build()
+    val JsonObjectBuilder: Symbol = Aeson.toBuilder()
+        .name("object")
+        .build()
+    val Value = Aeson.toBuilder().name("Value").build()
+    val TextPack: Symbol = Symbol.builder().name("pack").namespace("Data.Text", ".").build()
 
     val EncodingUtf8: Symbol = Symbol.builder()
         .name("encodeUtf8")
@@ -98,6 +105,16 @@ object HaskellSymbol {
     val ByteString: Symbol = Symbol.builder()
         .name("ByteString")
         .namespace("Data.ByteString", ".")
+        .dependencies(
+            SymbolDependency.builder()
+                .packageName("bytestring")
+                .version(CodegenUtils.depRange("0.10.12", "0.12.0"))
+                .build()
+        )
+        .build()
+    val ByteStringChar8 = Symbol.builder()
+        .name("N/A")
+        .namespace("Data.ByteString.Char8", ".")
         .dependencies(
             SymbolDependency.builder()
                 .packageName("bytestring")
@@ -281,5 +298,32 @@ object Http {
     val NewManager: Symbol = HttpClientModule.toBuilder()
         .name("newManager")
         .namespace(CLIENT_MODULE, ".")
+        .build()
+
+    val POSIXTime = Symbol.builder()
+        .name("POSIXTime")
+        .namespace("Data.Time.Clock.POSIX", ".")
+        .dependencies(
+            SymbolDependency.builder()
+                .packageName("time")
+                .version(CodegenUtils.depRange("1.9", "1.15"))
+                .build()
+        )
+        .build()
+
+    val UTCTime = POSIXTime.toBuilder()
+        .name("UTCTime")
+        .namespace("Data.Time", ".")
+        .build()
+
+    val HTTPDate = Symbol.builder()
+        .name("HTTPDate")
+        .namespace("Network.HTTP.Date", ".")
+        .dependencies(
+            SymbolDependency.builder()
+                .packageName("http-date")
+                .version(CodegenUtils.depRange("0.0.8", "0.1"))
+                .build()
+        )
         .build()
 }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellWriter.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/HaskellWriter.kt
@@ -93,6 +93,10 @@ class HaskellWriter(
         putContext("either", HaskellSymbol.Either)
         putContext("maybe", HaskellSymbol.Maybe)
         putContext("text", HaskellSymbol.Text)
+        putContext(
+            "textenc",
+            HaskellSymbol.Text.toBuilder().name("INVALID").namespace("Data.Text.Encoding", ".").build()
+        )
         putContext("just", HaskellSymbol.Maybe.toBuilder().name("Just").build())
         putContext("nothing", HaskellSymbol.Maybe.toBuilder().name("Nothing").build())
         putContext("right", HaskellSymbol.Either.toBuilder().name("Right").build())
@@ -129,6 +133,9 @@ class HaskellWriter(
     }
 
     private fun namespaceFormatter(sym: Any, ignored: String): String {
+        if (sym !is Symbol) {
+            println("$sym is not a symbol!")
+        }
         require(sym is Symbol)
         importContainer.importSymbol(sym, null)
         addDependency(sym)

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/SymbolExt.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/SymbolExt.kt
@@ -10,11 +10,21 @@ fun Symbol.isPrimitive(): Boolean = this.getProperty(SymbolProperties.IS_PRIMITI
     false
 )
 
-fun Symbol.wrap(sym: Symbol) = sym.toBuilder().addReference(this).build()
+val Symbol.isWrapper: Boolean
+    get() = this.getProperty(SymbolProperties.WRAPPER_T).getOrDefault(false)
+
+fun Symbol.wrap(sym: Symbol) = sym.toBuilder()
+    .addReference(this)
+    .putProperty(SymbolProperties.WRAPPER_T, true)
+    .build()
 
 fun Symbol.isMaybe() =
     this.name == HaskellSymbol.Maybe.name &&
         this.namespace == HaskellSymbol.Maybe.namespace
+
+fun Symbol.isEither() =
+    this.name == HaskellSymbol.Either.name &&
+        this.namespace == HaskellSymbol.Either.namespace
 
 fun Symbol.toMaybe(): Symbol {
     if (this.isMaybe()) {
@@ -29,6 +39,17 @@ fun Symbol.toEither(right: Symbol) = this.wrap(HaskellSymbol.Either)
     .build()
 
 fun Symbol.inIO() = this.wrap(HaskellSymbol.IO)
+
+fun Symbol.isOrWrapped(other: Symbol): Boolean {
+    if (this == other) {
+        return true
+    }
+    if (this.isEither()) {
+        // Checks against the `Right` reference.
+        return this.references[1].symbol == other
+    }
+    return this.isWrapper && this.references.first().symbol == other
+}
 
 fun SymbolReference.isDeclare() =
     this.options.any { it == SymbolReference.ContextOption.DECLARE }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureDeserializerGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureDeserializerGenerator.kt
@@ -1,18 +1,19 @@
 package io.superposition.smithy.haskell.client.codegen.generators
 
+import io.superposition.smithy.haskell.client.codegen.*
 import io.superposition.smithy.haskell.client.codegen.CodegenUtils.dq
-import io.superposition.smithy.haskell.client.codegen.HaskellWriter
-import io.superposition.smithy.haskell.client.codegen.jsonName
-import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
 
 class StructureDeserializerGenerator(
-    private val members: Collection<MemberShape>,
-    private val symbol: Symbol,
+    private val directive: HaskellShapeDirective<StructureShape>,
     private val writer: HaskellWriter,
 ) : Runnable {
     override fun run() {
+        val symbol = directive.symbol()
+        val members = directive.shape().members()
         val structName = symbol.name
+        writer.putContext("encoding", HaskellSymbol.EncodingUtf8)
+        writer.putContext("hdate", Http.HTTPDate)
         writer.openBlock("instance #{aeson:N}.FromJSON $structName where", "") {
             if (members.isEmpty()) {
                 writer.write("parseJSON = #{aeson:N}.withObject ${structName.dq} $ \\_ -> pure $ $structName")
@@ -28,7 +29,33 @@ class StructureDeserializerGenerator(
                     } else {
                         writer.writeInline("#{applicative:N}.<*> ")
                     }
-                    writer.write("v #{aeson:N}..: ${member.jsonName.dq}")
+                    val ms = directive.symbolProvider().toSymbol(member)
+                    val isHDate = ms.isOrWrapped(Http.HTTPDate)
+                    writer.writeInline("(v #{aeson:N}..: ${member.jsonName.dq}")
+                    if (isHDate) {
+                        val err = "Failed to parse $symbol.$ms as ${Http.HTTPDate}"
+                        val chainFn = if (ms.isMaybe()) {
+                            HaskellSymbol.FlippedFmap
+                        } else {
+                            HaskellSymbol.And
+                        }
+                        writer.write("")
+                        writer.indent()
+                        val cc = writer.newCallChain(" >>= \\t -> t", chainFn)
+                            .chain("#{encoding:N}.encodeUtf8")
+                            .chain("#{hdate:N}.parseHTTPDate")
+                            .chain("#{maybe:N}.maybe (fail ${err.dq}) pure")
+                        if (ms.isMaybe()) {
+                            cc.setChainFn(HaskellSymbol.And)
+                                .chain("#{maybe:N}.maybe (pure #{nothing:T}) pure")
+                        }
+                        cc.close()
+                        writer.write(")")
+                        writer.dedent()
+                    } else {
+                        writer.writeInline(")")
+                        writer.write("")
+                    }
                 }
             }
         }

--- a/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureGenerator.kt
+++ b/client-codegen/src/main/kotlin/io/superposition/smithy/haskell/client/codegen/generators/StructureGenerator.kt
@@ -19,7 +19,7 @@ class StructureGenerator<T : HaskellShapeDirective<StructureShape>>(
             #{record:C|}
 
             #{serializer:C|}
-            
+
             #{deserializer:C|}
 
             #{builder:C|}
@@ -34,11 +34,11 @@ class StructureGenerator<T : HaskellShapeDirective<StructureShape>>(
             writer.putContext("record", Runnable { writer.writeRecord(record) })
             writer.putContext(
                 "serializer",
-                StructureSerializerGenerator(shape.members(), symbol, writer)
+                StructureSerializerGenerator(directive, writer)
             )
             writer.putContext(
                 "deserializer",
-                StructureDeserializerGenerator(shape.members(), symbol, writer)
+                StructureDeserializerGenerator(directive, writer)
             )
             writer.putContext("builder", BuilderGenerator(record, symbol, writer))
             writer.write(template)

--- a/detekt.yml
+++ b/detekt.yml
@@ -75,10 +75,7 @@ style:
     active: true
     max: 3
   WildcardImport:
-    active: true
-    excludeImports:
-      - 'java.util.*'
-      - 'software.amazon.smithy.model.shapes.*'
+    active: false
 
 potential-bugs:
   active: true


### PR DESCRIPTION
`HTTPDate` does not have `Aeson` instances defined for it, so I have added additional serialization & de-serialization code wherever I though it will be needed. Lmk if I missed someplace.

PS: Disabled wild-card import linting, it's annoying.