### PR TITLE
fix: Fixed `runOperation` to use builder-error

### DIFF
--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestCustomStatus.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestCustomStatus.hs
@@ -22,6 +22,7 @@ data TestCustomStatusError =
 
 instance Data.Aeson.ToJSON TestCustomStatusError
 instance Com.Example.Utility.OperationError TestCustomStatusError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestErrors.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestErrors.hs
@@ -24,6 +24,7 @@ data TestErrorsError =
 
 instance Data.Aeson.ToJSON TestErrorsError
 instance Com.Example.Utility.OperationError TestErrorsError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpDocument.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpDocument.hs
@@ -22,6 +22,7 @@ data TestHttpDocumentError =
 
 instance Data.Aeson.ToJSON TestHttpDocumentError
 instance Com.Example.Utility.OperationError TestHttpDocumentError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpDocumentDeserialization.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpDocumentDeserialization.hs
@@ -22,6 +22,7 @@ data TestHttpDocumentDeserializationError =
 
 instance Data.Aeson.ToJSON TestHttpDocumentDeserializationError
 instance Com.Example.Utility.OperationError TestHttpDocumentDeserializationError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpHeaders.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpHeaders.hs
@@ -22,6 +22,7 @@ data TestHttpHeadersError =
 
 instance Data.Aeson.ToJSON TestHttpHeadersError
 instance Com.Example.Utility.OperationError TestHttpHeadersError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpLabels.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpLabels.hs
@@ -22,6 +22,7 @@ data TestHttpLabelsError =
 
 instance Data.Aeson.ToJSON TestHttpLabelsError
 instance Com.Example.Utility.OperationError TestHttpLabelsError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpPayload.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpPayload.hs
@@ -22,6 +22,7 @@ data TestHttpPayloadError =
 
 instance Data.Aeson.ToJSON TestHttpPayloadError
 instance Com.Example.Utility.OperationError TestHttpPayloadError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpPayloadDeserialization.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestHttpPayloadDeserialization.hs
@@ -22,6 +22,7 @@ data TestHttpPayloadDeserializationError =
 
 instance Data.Aeson.ToJSON TestHttpPayloadDeserializationError
 instance Com.Example.Utility.OperationError TestHttpPayloadDeserializationError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestQuery.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestQuery.hs
@@ -22,6 +22,7 @@ data TestQueryError =
 
 instance Data.Aeson.ToJSON TestQueryError
 instance Com.Example.Utility.OperationError TestQueryError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestReservedWords.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Command/TestReservedWords.hs
@@ -22,6 +22,7 @@ data TestReservedWordsError =
 
 instance Data.Aeson.ToJSON TestReservedWordsError
 instance Com.Example.Utility.OperationError TestReservedWordsError where
+    mkBuilderError = BuilderError
     mkDeSerializationError = DeSerializationError
     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Utility.hs
+++ b/client-codegen-test/output/source/haskell-client-codegen/Com/Example/Utility.hs
@@ -513,6 +513,7 @@ instance ToJSON HttpMetadata
 
 class OperationError e where
   getErrorParser :: HTTP.Status -> Maybe (HttpResponseParser e)
+  mkBuilderError :: Text -> e
   mkDeSerializationError :: HttpMetadata -> Text -> e
   mkUnexpectedError :: Maybe HttpMetadata -> Text -> e
 
@@ -529,7 +530,7 @@ runOperation ::
 runOperation _ _ _ (Left err) =
   pure $
     Left $
-      mkUnexpectedError Nothing err
+      mkBuilderError err
 runOperation endpoint manager setAuth (Right i) = do
   let rbuilder = intoRequestBuilder i >> setAuth >> setContentType
       (_, reqSt) = MTL.runState rbuilder newRequestBuilderSt

--- a/client-codegen/src/main/kotlin/in/juspay/smithy/haskell/client/codegen/generators/OperationGenerator.kt
+++ b/client-codegen/src/main/kotlin/in/juspay/smithy/haskell/client/codegen/generators/OperationGenerator.kt
@@ -111,6 +111,7 @@ class OperationGenerator<T : HaskellShapeDirective<OperationShape>>(
                 #{struct:C}
                 instance #{aeson:N}.ToJSON $operationErrorName
                 instance #{utility:N}.OperationError $operationErrorName where
+                    mkBuilderError = BuilderError
                     mkDeSerializationError = DeSerializationError
                     mkUnexpectedError = UnexpectedError
 

--- a/client-codegen/src/main/resources/utility.hs
+++ b/client-codegen/src/main/resources/utility.hs
@@ -489,6 +489,7 @@ instance ToJSON HttpMetadata
 
 class OperationError e where
   getErrorParser :: HTTP.Status -> Maybe (HttpResponseParser e)
+  mkBuilderError :: Text -> e
   mkDeSerializationError :: HttpMetadata -> Text -> e
   mkUnexpectedError :: Maybe HttpMetadata -> Text -> e
 
@@ -505,7 +506,7 @@ runOperation ::
 runOperation _ _ _ (Left err) =
   pure $
     Left $
-      mkUnexpectedError Nothing err
+      mkBuilderError err
 runOperation endpoint manager setAuth (Right i) = do
   let rbuilder = intoRequestBuilder i >> setAuth >> setContentType
       (_, reqSt) = MTL.runState rbuilder newRequestBuilderSt


### PR DESCRIPTION
Fixed `runOperation` to return a builder-error when input-builder is incorrect.